### PR TITLE
Latejoin Cyborg slot

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -4,7 +4,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 1 //GS13 Edit: latejoining borgs
 	spawn_positions = 3
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Brings back the ability to latejoin as a cyborg, though only one as specified in oldcode.

![borg](https://github.com/user-attachments/assets/0a331fe9-c072-419f-a974-4060e5dfcd98)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Content restoration and allows players to play as silicons even with total scientist absence. 
See: https://discord.com/channels/1348067328876609587/1351568518092554330/1351569142565703813

## Changelog
:cl:
tweak: Re-adds a single latejoin borg slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
