### PR TITLE
Connected and Active Players on statpanel

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -13,10 +13,12 @@ SUBSYSTEM_DEF(statpanels)
 	if (!resumed)
 		var/datum/map_config/cached = SSmapping.next_map_config
 		var/round_time = world.time - SSticker.round_start_time
+		var/active_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE) //GS13 Edit: Get active in round players, even those who are dead
 		var/list/global_data = list(
 			"Map: [SSmapping.config?.map_name || "Loading..."]",
 			cached ? "Next Map: [cached.map_name]" : null,
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
+			"Connected Players: [GLOB.clients.len] | Active Players: [active_players]", //GS13 Edit: Active & connected (and likely observing) players
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]",
 			"Round Time: [GAMETIMESTAMP("hh:mm:ss", round_time)]",
 			"Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds the ability to see connected and active in round players (connected, not SSD) counts on the statpanel.

![statpanel](https://github.com/user-attachments/assets/fc574f4c-5fce-48f8-be99-68ca79c46558)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This gives players the ability to see who is actively playing and is connected when joining, somewhat mitigating the situation of seeing multiple people on the manifest but none of them are active once entering or checking the who verb.

## Changelog
:cl:
add: Statpanel now shows connected and in-game player counts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
