### PR TITLE
Ashwalker custom avatar fix

### DIFF
--- a/hyperstation/code/modules/mob/mob_helpers.dm
+++ b/hyperstation/code/modules/mob/mob_helpers.dm
@@ -1,8 +1,11 @@
-mob/proc/checkloadappearance()
+/mob/proc/checkloadappearance()
 	var/mob/living/carbon/human/H = src
 	if(!istype(H))
 		return FALSE
-
+	//GS13 EDIT start
+	var/datum/species/A = /datum/species/lizard/ashwalker //GS13 EDIT let ashwalkers have custom avatars
+	var/ashie = (H.dna.species.id == SPECIES_ASHWALKER)
+	//GS13 EDIT end
 	//This will be where the person gets to select their appearance instead of the random character
 	if (H.mirrorcanloadappearance == TRUE)
 		SEND_SOUND(H, 'sound/misc/server-ready.ogg')
@@ -21,6 +24,7 @@ mob/proc/checkloadappearance()
 					idCard.update_label(H.real_name, idCard.assignment)
 					idCard.registered_name = H.real_name
 				H.mirrorcanloadappearance = FALSE //Prevents them from using the mirror again.
+				if(ashie) H.set_species(A) //GS13 EDIT
 				ADD_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT) //Makes sure they are exempt from health events.
 				SEND_SOUND(H, 'sound/magic/charge.ogg') //Fluff
 				to_chat(H, "<span class='boldannounce'>Your head aches for a second. You feel like this is how things should have been.</span>")


### PR DESCRIPTION
## About The Pull Request
Now ashwalker enjoyers can load their custom avatars/characters and not suffocate or being affected by ash storm (as ashwalkers normaly do)
Plus this fix allows wg for ashwalker characters (belly and other genitals from character creation menu)
![image](https://github.com/user-attachments/assets/784e6ceb-7b2f-40a7-ac12-a999b80909d0)
![image](https://github.com/user-attachments/assets/a4a932d0-bebf-4c3a-a6de-2d89cd454241)
![image](https://github.com/user-attachments/assets/d30130be-f33b-4f99-942b-6910fd04e9c1)

## Why It's Good For The Game
Bug fixing, no more random generated ashwalkers. More ashwalker OC 


## Changelog
:cl:
fix: fixed a few things
:cl:
