### PR TITLE
Fix for crew medical records not showing quirks on latejoiners

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -504,7 +504,6 @@
 		humanc = character	//Let's retypecast the var to be human,
 
 	if(humanc)	//These procs all expect humans
-		GLOB.data_core.manifest_inject(humanc, humanc.client, humanc.client.prefs)
 		if(SSshuttle.arrivals)
 			SSshuttle.arrivals.QueueAnnounce(humanc, rank)
 		else
@@ -539,6 +538,9 @@
 
 	if(humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client, TRUE, FALSE, job, FALSE)
+
+	if(humanc) //GS13 - Inject to manifest only after quirks have been applied
+		GLOB.data_core.manifest_inject(humanc, humanc.client, humanc.client.prefs)
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Crew medical records were not showing quirks at all for anyone that latejoined (which is often 100% of the station population at any given time). Looking around, this problem happens because quirks are added to the player after being injected to the crew manifest which is when they get added to the records consoles. This fixes the issue by adding quirks first before adding to the manifest.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes quirks actually show in medical records for every latejoin crew member.

## Changelog
:cl:
fix: Latejoiners now have their quirks show in the medical records
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
