### PR TITLE
Unbreak cloning for players with deleted bodies

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -46,7 +46,7 @@
 	dispose_rendering()
 	qdel(hud_used)
 	QDEL_LIST(client_colours)
-	ghostize(can_reenter_corpse = FALSE) //False, since we're deleting it currently
+	ghostize()
 	if(mind?.current == src) //Let's just be safe yeah? This will occasionally be cleared, but not always. Can't do it with ghostize without changing behavior
 		mind.set_current(null)
 	// if(mock_client)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Imports a fix from Citadel with cloning being inaccessible for players who have their bodies fully removed via being dusted, certain types of gibbing, or just deleted. 

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/16129

"For the curious, replication steps: Have your body be deleted by gibbing, dusting and otherwise other methods of deletion, if you DON'T leave your body as a ghost "can_reenter_body" will be FALSE, locking any revival."

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This should fix some strange cases of cloning failures if the body just doesn't exist in the world anymore.

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
