### PR TITLE
Fix for issue with plumbing reaction chambers getting stuck on filling 

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -88,6 +88,9 @@
 #define REACTION_CLEAR_IMPURE       (1<<0)  //Convert into impure/pure on reaction completion
 #define REACTION_CLEAR_INVERSE      (1<<1)  //Convert into inverse on reaction completion when purity is low enough
 
+///The minimum volume of reagents than can be operated on.
+#define CHEMICAL_QUANTISATION_LEVEL 0.0001
+
 //Chemical blacklists for smartdarts
 GLOBAL_LIST_INIT(blacklisted_medchems, list(
 	/datum/reagent/medicine/morphine, /datum/reagent/medicine/haloperidol,	//harmful chemicals in medicine

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -88,6 +88,7 @@
 #define REACTION_CLEAR_IMPURE       (1<<0)  //Convert into impure/pure on reaction completion
 #define REACTION_CLEAR_INVERSE      (1<<1)  //Convert into inverse on reaction completion when purity is low enough
 
+///GS13 edit
 ///The minimum volume of reagents than can be operated on.
 #define CHEMICAL_QUANTISATION_LEVEL 0.0001
 

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -66,9 +66,14 @@
 		var/datum/component/plumbing/supplier = A
 		if(supplier.can_give(amount, reagent, net))
 			valid_suppliers += supplier
+	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down and become 0
+	var/targetVolume = reagents.total_volume = amount
+	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)
 		var/datum/component/plumbing/give = A
-		give.transfer_to(src, amount / valid_suppliers.len, reagent, net)
+		var/currentRequest = (targetVolume - reagents.total_volume) / suppliersLeft
+		give.transfer_to(src, currentRequest, reagent, net)
+		suppliersLeft--
 ///returns TRUE when they can give the specified amount and reagent. called by process request
 /datum/component/plumbing/proc/can_give(amount, reagent, datum/ductnet/net)
 	if(amount <= 0)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -66,7 +66,7 @@
 		var/datum/component/plumbing/supplier = A
 		if(supplier.can_give(amount, reagent, net))
 			valid_suppliers += supplier
-	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down and become 0
+	///GS13 Edit: Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down and become 0
 	var/targetVolume = reagents.total_volume = amount
 	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -71,6 +71,7 @@
 	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)
 		var/datum/component/plumbing/give = A
+		//GS13 Edit: See above comment
 		var/currentRequest = (targetVolume - reagents.total_volume) / suppliersLeft
 		give.transfer_to(src, currentRequest, reagent, net)
 		suppliersLeft--

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -23,7 +23,7 @@
 			var/datum/reagent/RD = A
 			if(RT == RD.type)
 				has_reagent = TRUE
-				if(RD.volume < RC.required_reagents[RT])
+				if(RD.volume + CHEMICAL_QUANTISATION_LEVEL < RC.required_reagents[RT]) // Allow the chamber to exit filling mode when it feels it has enough even if short by a tiny fraction
 					process_request(min(RC.required_reagents[RT] - RD.volume, MACHINE_REAGENT_TRANSFER) , RT, dir)
 					return
 		if(!has_reagent)

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -23,7 +23,7 @@
 			var/datum/reagent/RD = A
 			if(RT == RD.type)
 				has_reagent = TRUE
-				if(RD.volume + CHEMICAL_QUANTISATION_LEVEL < RC.required_reagents[RT]) // Allow the chamber to exit filling mode when it feels it has enough even if short by a tiny fraction
+				if(RD.volume + CHEMICAL_QUANTISATION_LEVEL < RC.required_reagents[RT]) //GS13 Edit: Allow the chamber to exit filling mode when it feels it has enough even if short by a tiny fraction
 					process_request(min(RC.required_reagents[RT] - RD.volume, MACHINE_REAGENT_TRANSFER) , RT, dir)
 					return
 		if(!has_reagent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR imports a fix from TG with chem factories, particularly the reaction chambers stalling when a chemical enters it with 0.999 units because of rounding, the reaction chamber attempts to get the remaining amount but it ends up being rounded to 0 thus causing the chamber to stall. The full details of why this occurs is below:

From the original PR: https://github.com/tgstation/tgstation/pull/59131

> This Pull Requests aims to fix the issue https://github.com/tgstation/tgstation/issues/58993 by changing two parts of the logic I've seen the chambers get stuck on.
> 
> Chamber gets stuck requesting a unit that is always rounded down to 0
> Chamber gets stuck requesting an insanely small number that gets eaten by float math
> 
> Part 1 Explanation
> Take the example where a chamber is trying to request one unit of chemical from three synthesizers. A chamber will divide it's request amongst all suppliers who can satisfy it. In this case, 1 / 3 becomes asking each synthesizer for 0.33 (due to rounding). After one update, the chamber has 0.99 of the chemical, not 1. On the second update, it then requires 0.01 of the chemical and asks each chamber for 0.0033, which gets rounded down to 0. This means the chamber NEVER fills as it spends every update cycle doing the same logic and trying to transfer in parts of 0 in size.
> 
> This has been fixed by changing it from flat dividing the amount required by the number of suppliers to a more dynamic approach that looks at the target volume and how many requests it needs to make. This mean that instead of asking for 0.33 three times in the above example, it actually works out more to asking for 0.33 then 0.34 then 0.33. Meaning it gets the whole 1 it wanted in the first update, fixing the issue.
> 
> Part 2 Explanation
> Even with the above fix, when working with the right numbers, floats do not add as expected. Take the above example. I lied. 1/3 as a float is NOT 0.33. 0.33 does not exist as a float, so the actual closest value is 0.32999998, which is what the code will use, even when rounding to 0.01. What this causes is, in some scenarios, chambers getting incredibly close to their target volume but never being able to actually reach it because currentVolume + missingAmount comes out as just currentVolume, due to the insanely small float that it's missing having no impact on the larger float when added together. Again, this is due to how floats work.
> 
> So to avoid a chamber getting stuck on 98.9999999998 when it needs 99, I'm adding the CHEMICAL_QUANTISATION_LEVEL constant (used elsewhere for similar issues) to the chamber's volume when checking if it has enough. This way, the chamber will exit the filling mode even though it was short by a tiny fraction. These discrepancies seem to get handled anyway in the actual reaction code so I haven't seen any changes/problems to my outputs. For all intents and purposes, 98.9999999998 is 99 in float arithmetic when rounding as we do.
> 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes an oversight with chemistry factories getting stuck when they shouldn't due to math errors.


## Changelog
:cl: mGuv
fix: fixed issue where plumbing Reaction Chambers get stuck on "Filling"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
