### PR TITLE
Eating sound pref fix

### DIFF
--- a/GainStation13/code/clothing/bluespace_collar.dm
+++ b/GainStation13/code/clothing/bluespace_collar.dm
@@ -73,8 +73,8 @@
 	if(owner.reagents)
 		if(eater.satiety > -200)
 			eater.satiety -= owner.junkiness
-		playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
-		playsound(original_eater.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+		playsound_prefed(eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
+		playsound_prefed(original_eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
 		eater.visible_message("<span class='warning'>[eater]'s belly seems to visibly distend a bit further'!</span>", "<span class='danger'>You feel your stomach get filled by food!</span>")
 		var/bitevolume = 1
 		if(HAS_TRAIT(original_eater, TRAIT_VORACIOUS))
@@ -105,8 +105,8 @@
 		return FALSE
 	if(eater.satiety > -200)
 		eater.satiety -= foodstuff.junkiness
-	playsound(original_eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
-	playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	playsound_prefed(original_eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), TRUE)
+	playsound_prefed(eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), TRUE)
 	eater.visible_message("<span class='warning'>[eater]'s belly seems to visibly distend a bit further'!</span>", "<span class='danger'>You feel your stomach get filled by something!</span>")
 	var/mob/living/carbon/human/human_eater = original_eater
 	if(istype(human_eater))

--- a/GainStation13/code/mechanics/metal_cruncher.dm
+++ b/GainStation13/code/mechanics/metal_cruncher.dm
@@ -16,7 +16,7 @@
 				user.visible_message("<span class='notice'>[user] crunches on some of [src].</span>", "<span class='notice'>You crunch on some of [src].</span>")
 			else
 				M.visible_message("<span class='danger'>[user] attempts to feed some of [src] to [M].</span>", "<span class='userdanger'>[user] attempts to feed some of [src] to [M].</span>")
-			playsound(M,'sound/items/eatfood.ogg', rand(10,50), 1)
+			playsound_prefed(M,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
 			use(1)
 			M.nutrition += crunch_value
 			//if(HAS_TRAIT(M, TRAIT_VORACIOUS))

--- a/GainStation13/code/modules/food_and_drinks/metal_food.dm
+++ b/GainStation13/code/modules/food_and_drinks/metal_food.dm
@@ -19,7 +19,7 @@
 				user.visible_message("<span class='notice'>[user] crunches on some of [src].</span>", "<span class='notice'>You crunch on some of [src].</span>")
 			else
 				M.visible_message("<span class='danger'>[user] attempts to feed some of [src] to [M].</span>", "<span class='userdanger'>[user] attempts to feed some of [src] to [M].</span>")
-			playsound(M,'sound/items/eatfood.ogg', rand(10,50), 1)
+			playsound_prefed(M,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
 			use(1)
 			M.nutrition += crunch_value
 			if(crunch_left == 0)

--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -165,7 +165,7 @@ Behavior that's still missing from this component that original food items had t
 		return FALSE
 	if(eater.satiety > -200)
 		eater.satiety -= junkiness
-	playsound(eater.loc,'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	playsound_prefed(eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), TRUE)
 	var/mob/living/carbon/human/human_eater = eater
 	if(istype(human_eater))
 		var/bitevolume = 1

--- a/code/datums/components/edible.dm
+++ b/code/datums/components/edible.dm
@@ -165,7 +165,9 @@ Behavior that's still missing from this component that original food items had t
 		return FALSE
 	if(eater.satiety > -200)
 		eater.satiety -= junkiness
+	//GS13 Edit- Eating sound prefs
 	playsound_prefed(eater.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), TRUE)
+	//GS13 Edit end
 	var/mob/living/carbon/human/human_eater = eater
 	if(istype(human_eater))
 		var/bitevolume = 1

--- a/code/datums/elements/trash.dm
+++ b/code/datums/elements/trash.dm
@@ -9,7 +9,9 @@
 	if((M == user || user.vore_flags & TRASH_FORCEFEED) && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
+			//GS13 Edit - Eating sound prefs
 			playsound_prefed(H.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
+			//GS13 Edit end
 			if(H.vore_selected)
 				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [source.name] into their [H.vore_selected.name]</span>",
 					"<span class='notice'>You [H.vore_selected.vore_verb] the [source.name] into your [H.vore_selected.name]</span>")

--- a/code/datums/elements/trash.dm
+++ b/code/datums/elements/trash.dm
@@ -9,7 +9,7 @@
 	if((M == user || user.vore_flags & TRASH_FORCEFEED) && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
-			playsound(H.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+			playsound_prefed(H.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
 			if(H.vore_selected)
 				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [source.name] into their [H.vore_selected.name]</span>",
 					"<span class='notice'>You [H.vore_selected.vore_verb] the [source.name] into your [H.vore_selected.name]</span>")

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -172,7 +172,9 @@ All foods are distributed among various categories. Use common sense.
 			if(reagents)								//Handle ingestion of the reagent.
 				if(M.satiety > -200)
 					M.satiety -= junkiness
+				//GS13 Edit - Eating sound prefs
 				playsound_prefed(M.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
+				//GS13 Edit end
 				var/bitevolume = 1
 				if(HAS_TRAIT(M, TRAIT_VORACIOUS))
 					bitevolume = bitevolume * 0.67

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -172,7 +172,7 @@ All foods are distributed among various categories. Use common sense.
 			if(reagents)								//Handle ingestion of the reagent.
 				if(M.satiety > -200)
 					M.satiety -= junkiness
-				playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+				playsound_prefed(M.loc,'sound/items/eatfood.ogg', EATING_NOISES, rand(10,50), 1)
 				var/bitevolume = 1
 				if(HAS_TRAIT(M, TRAIT_VORACIOUS))
 					bitevolume = bitevolume * 0.67


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

we've all had those moments where 5 people descend on the bar at a single time and eat every single food item at once. or youre trying to have a conversation but one person is off in the corner eating 5 cakes in a row and you cant even hear yourself think. ive wanted to be able to turn this off, and we already actually have a pref for eating sounds. i mistakenly thought it applied to eating food but actually it's only for vore, so i made it apply to all eating sounds.
tested. compiles, and sound follows pref on junk food, metal sheets, food food, trash eating, and bluespace collar.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

now players can mute specifically eating sounds when it gets to be annoying rather than having to mute their volume or take their headphones off

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: food eating sounds now follow the Hear Eating noises preference
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
