### PR TITLE
Lipoifium update

### DIFF
--- a/GainStation13/code/mechanics/fattening_gasses.dm
+++ b/GainStation13/code/mechanics/fattening_gasses.dm
@@ -7,18 +7,23 @@
 
 	var/total_moles = breath.total_moles()
 	var/lipoifium_moles = breath.get_moles(GAS_FAT)
-	#define PP_MOLES(X) ((X / total_moles) * pressure) // this needs to be here because spaghetti, I'm sorry
+	var/pressure = breath.return_pressure()
+	var/lipoifium_partial_pressure = pressure * lipoifium_moles / total_moles
+	// #define PP_MOLES(X) ((X / total_moles) * pressure) // this needs to be here because spaghetti, I'm sorry
 	if(lipoifium_moles <= 0)
 		return
 
-	H.adjust_fatness(lipoifium_moles * 1500, FATTENING_TYPE_ATMOS)
+	var/fatness_to_add = lipoifium_moles * 150	// each mole gives 150 BFI. Now, you may think that that's A METRIC FUCKTON, but in reality, because lungs by default are 0.5 liters, at 20C 101.325 kPa that's just 0.02 moles
+	fatness_to_add *= 10 * lipoifium_moles / total_moles
+	H.adjust_fatness(fatness_to_add + 5, FATTENING_TYPE_ATMOS)
 	breath.set_moles(GAS_FAT, 0)
-	// TODO: the entire code below is a workaround for default odor not working
+	// TODO: the 3 lines below are a workaround for default odor not working
 	// The problem seems to be auxmos'es get_gasses function not acknowledging that lipoifium exists
 	// which is strange, considering that everything else regarding this gas and auxmos works
-	var/smell_chance = min(lipoifium_moles * 100 / total_moles, 20)
+	var/smell_chance = clamp((lipoifium_partial_pressure - 100) / 2.5, 0, 20)
+	// var/smell_chance = min(lipoifium_moles * 100 / total_moles, 5)
 	if(prob(smell_chance))
-		to_chat(owner, "<span class='notice'>You can smell lard.</span>")
+		to_chat(owner, "<span class='notice'>" + pick("You can smell lard.", "Your clothes feel tight.", "You can feel yourself expand.") + "</span>")
 
 
 /obj/item/organ/lungs/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/H)

--- a/GainStation13/code/mechanics/water_sponge.dm
+++ b/GainStation13/code/mechanics/water_sponge.dm
@@ -49,9 +49,11 @@
 		if(breath)
 			var/pressure = breath.return_pressure()
 			var/total_moles = breath.total_moles()
-			//#define PP_MOLES(X) ((X / total_moles) * pressure)
+			#define PP_MOLES(X) ((X / total_moles) * pressure)
 			#define PP(air, gas) PP_MOLES(air.get_moles(gas))
 			var/gas_breathed = PP(breath,GAS_H2O)
+			#undef PP_MOLES
+			#undef PP
 			if(gas_breathed > 0)
 				H.reagents.add_reagent(/datum/reagent/water, gas_breathed)
 				breath.adjust_moles(GAS_H2O, -gas_breathed)

--- a/GainStation13/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/GainStation13/code/modules/atmospherics/auxgm/gas_types.dm
@@ -2,8 +2,8 @@
 	id = GAS_FAT
 	specific_heat = 20
 	name = "Lipoifium"
-	moles_visible = MOLES_GAS_VISIBLE
-	color = "#e2e1b1"
+	// moles_visible = MOLES_GAS_VISIBLE
+	// color = "#e2e1b1"
 	odor = "that this is a function that wasn't working, but it now, for some reason, is. You should speak to the gods about this and the conditions under which it happened"
 	odor_strength = 1 // TODO: doesn't work for now
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates how Lipoifium is obtained and how it fattens up

- Tweaks lipoifium fattening formula, increasing the amount of BFI generated at low concentrations while not drastically increasing the ceiling
- Tweaks the way smell chance is calculated. It will not not be possible to smell it below a certain Partial Pressure, after which it will ramp up to 20%
- Adds more flavor text for lipoifium smell
- Makes lipoifium invisible
- Makes it easier to obtain lipoifium:
    - it now requires Plasma instead of BZ to form
    - It requires a lot less plasma and tritium to start forming
    - the formation speed is now dependant on the amount of moles in the reaction as well as reaction efficiency, capped at 20 per tick
- Updates the code for the water sponge, since before there was a bit of spaghetti there for some reason. If anything related to gasses breaks, this is probably a good place to start looking

## Why It's Good For The Game

This should open up more RP opportunities, while making lipoifium easier to obtain
