### PR TITLE
Disabling Global OOC should no longer disable LOOC

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -17,8 +17,8 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 	if(!msg)
 		return
 
-	if(!(prefs.chat_toggles & CHAT_OOC))
-		to_chat(src, "<span class='danger'> You have OOC muted.</span>")
+	if(!(prefs.chat_toggles & CHAT_LOOC)) //GS13 - LOOC toggle tweaks, OOC toggle should not disable LOOC
+		to_chat(src, "<span class='danger'> You have LOOC muted.</span>")
 		return
 	if(jobban_isbanned(mob, "OOC"))
 		to_chat(src, "<span class='danger'>You have been banned from OOC.</span>")
@@ -60,14 +60,14 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 	for(var/turf/viewed_turf in view(get_turf(mob)))
 		in_view[viewed_turf] = TRUE
 	for(var/client/client in GLOB.clients)
-		if(!client.mob || !(client.prefs.toggles & CHAT_OOC) || (client in GLOB.admins))
+		if(!client.mob || !(client.prefs.toggles & CHAT_LOOC) || (client in GLOB.admins))
 			continue
 		if(in_view[get_turf(client.mob)])
 			targets |= client
 			to_chat(client, "<span class='looc'><span class='prefix'>LOOC:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")
 
 	for(var/client/client in GLOB.admins)
-		if(!(client.prefs.toggles & CHAT_OOC))
+		if(!(client.prefs.toggles & CHAT_LOOC))
 			continue
 		var/prefix = "(R)LOOC"
 		to_chat(client, "<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[ADMIN_LOOKUPFLW(usr)]:</EM> <span class='message'>[msg]</span></span>", avoid_highlighting = (client == src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes it so the OOC and LOOC preference toggles disable their respective chats rather than the former disabling both.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Some people (especially myself) would prefer to disable global OOC while keeping LOOC enabled

## Changelog
:cl:
tweak: Global OOC toggle no longer disables LOOC 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
