### PR TITLE
Fix for missing ripley mk2 conversion kit

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -72,6 +72,16 @@
 	construction_time = 100
 	category = list("Ripley")
 
+//GS13: MK-II Ripley Kit
+/datum/design/ripleyupgrade
+	name = "Ripley MK-1 to MK-II Conversion Kit"
+	id = "ripleyupgrade"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/mecha_equipment/ripleyupgrade
+	materials = list(/datum/material/iron=10000,/datum/material/plasma=10000)
+	construction_time = 100
+	category = list("Ripley")
+
 //firefighter subtype
 /datum/design/firefighter_chassis
 	name = "Exosuit Chassis (APLU \"Firefighter\")"

--- a/code/modules/research/techweb/nodes/mecha_nodes.dm
+++ b/code/modules/research/techweb/nodes/mecha_nodes.dm
@@ -7,7 +7,7 @@
 	display_name = "Mechanical Exosuits"
 	description = "Mechanized exosuits that are several magnitudes stronger and more powerful than the average human."
 	design_ids = list("mecha_tracking", "mechacontrol", "mechapower", "mech_recharger", "ripley_chassis", "firefighter_chassis", "ripley_torso", "ripley_left_arm", "ripley_right_arm", "ripley_left_leg", "ripley_right_leg",
-	"ripley_main", "ripley_peri", "mech_hydraulic_clamp")
+	"ripley_main", "ripley_peri", "ripleyupgrade", "mech_hydraulic_clamp") //GS13: MK-II Ripley Kit
 
 /datum/techweb_node/mech_tools
 	id = "mech_tools"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Restores the missing MK-II kit for the Ripley to the fabricator complete with techweb support.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Missing content fix!

## Changelog
:cl:
fix: Ripley MK-II conversion kits can be fabricated again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
