### PR TITLE
Dual tone suit round/stuffed belly fix

### DIFF
--- a/GainStation13/code/modules/clothing/under/jobs/modular_items.dm
+++ b/GainStation13/code/modules/clothing/under/jobs/modular_items.dm
@@ -285,3 +285,28 @@
 /obj/item/clothing/under/color/dual_tone/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/polychromic, suit_colors, 2, can_be_modified = FALSE)
+
+/obj/item/clothing/under/color/dual_tone/get_belly_size(obj/item/organ/genital/G)
+	var/size = G.size
+	if(G.size > 9)
+		size = 9
+	var/shape = "soft"
+	// if(G.owner.fullness <= FULLNESS_LEVEL_BLOATED)
+	// 	switch(G.shape)
+	// 		if("Soft Belly")
+	// 			shape = "soft"
+	// 		if("Round Belly")
+	// 			shape = "round"
+	// else
+	// 	shape = "stuffed"
+	var/stuffed_modifier
+	switch(G.owner.fullness)
+		if(FULLNESS_LEVEL_BLOATED to FULLNESS_LEVEL_BEEG) // Take the stuffed sprite of the same size
+			stuffed_modifier = 0
+		if(FULLNESS_LEVEL_BEEG to FULLNESS_LEVEL_NOMOREPLZ) // Take the stuffed sprite of size + 1
+			stuffed_modifier = 1
+		if(FULLNESS_LEVEL_NOMOREPLZ to INFINITY)// Take the stuffed sprite of size + 2
+			stuffed_modifier = 2
+	size = size + stuffed_modifier
+
+	return "[shape]_[size]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix for the round/stuffed belly sprites not showing with the dual tone suit. Right now I just axed them for the suit, but if we ever make stuffed/round sprites for it I can include them back.

## Why It's Good For The Game

More bellies...
