### PR TITLE
Make hardsuits protect from snaxi's snowstorms

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -48,6 +48,8 @@
 	if(suit && !ismob(loc)) //equipped() will handle mob cases, so it doesn't disengage twice.
 		suit.RemoveHelmet()
 		soundloop.stop(user)
+	if(HAS_TRAIT_FROM(user, TRAIT_SNOWSTORM_IMMUNE, "hardsuit")) ///GS13 Edit - Hardsuits protect from snowstorms
+		REMOVE_TRAIT(user, TRAIT_SNOWSTORM_IMMUNE, "hardsuit")
 
 /obj/item/clothing/head/helmet/space/hardsuit/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == ITEM_SLOT_HEAD)
@@ -63,6 +65,7 @@
 			qdel(src)
 	else
 		soundloop.start(user)
+		ADD_TRAIT(user, TRAIT_SNOWSTORM_IMMUNE, "hardsuit") //GS13 Edit - Hardsuits protect from snowstorms
 
 /obj/item/clothing/head/helmet/space/hardsuit/proc/display_visor_message(var/msg)
 	var/mob/wearer = loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
One of Snow Taxi's main issues is that outside on the main surface is the regular snowstorms, this itself isn't a problem but the lack of any equipment to resist it is. Hardsuits already protect the user from extreme cold, this makes it so the surface during storms is traversable as long as you're wearing it. This affects all hardsuits that use "/obj/item/clothing/head/helmet/space/hardsuit" for their definition.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Having some means to make surface dwelling on snow taxi less of a hassle is pretty useful

## Changelog
:cl:
tweak: Hardsuits now protect you from snaxi's snowstorms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
